### PR TITLE
Fixes bug, removed Kanal for now, switched to main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ async-io = "1.9.0"
 byteorder = "1.4.3"
 crc = "3.0.0"
 serde_json = "1.0"
-kanal = {version = "0.1.0-pre1", features = ["async"]}
 futures-core = { version = "0.3.24" }
 futures-util = { version = "0.3.24", features = ["sink"] }
 futures = "0.3.24"
@@ -33,6 +32,7 @@ rand = "0.8.5"
 socket2 = "0.4.7"
 hashbrown = "0.12.3"
 atone = "0.3.5"
+flume = "0.10.14"
 
 [dev-dependencies]
 clap = "3.0"


### PR DESCRIPTION
This PR starts a change of the webrtc-unreliable fork, changing the name in order to not confuse users